### PR TITLE
refactor: changed Err to automatically implement Send + Sync

### DIFF
--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -23,7 +23,7 @@ unsafe impl<T: Send + Sync> Send for SendSyncNonNull<T> {}
 unsafe impl<T: Send + Sync> Sync for SendSyncNonNull<T> {}
 
 impl<T: Send + Sync> SendSyncNonNull<T> {
-    pub fn as_ptr(&self) -> *mut T {
+    fn as_ptr(&self) -> *mut T {
         self.0.as_ptr()
     }
 }

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -23,7 +23,7 @@ unsafe impl<T: Send + Sync> Send for SendSyncNonNull<T> {}
 unsafe impl<T: Send + Sync> Sync for SendSyncNonNull<T> {}
 
 impl<T: Send + Sync> SendSyncNonNull<T> {
-    fn as_ptr(&self) -> *mut T {
+    pub fn as_ptr(&self) -> *mut T {
         self.0.as_ptr()
     }
 }


### PR DESCRIPTION
This PR adds a new struct: `SendSyncNonNull` which hold a pointer that is `Send + Sync`.

By this struct, the `Err` struct is made thread-safe and automatically implement `Send + Sync`.