### PR TITLE
update!: made the notification implementation more safety

### DIFF
--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -7,7 +7,7 @@ use crate::{Err, ReasonContainer, SendSyncNonNull};
 #[cfg(feature = "notify")]
 mod notify;
 #[cfg(feature = "notify")]
-pub use notify::{__add_async_err_handler, add_sync_err_handler, fix_err_handlers};
+pub use notify::{add_raw_async_err_handler, add_sync_err_handler, fix_err_handlers};
 #[cfg(feature = "notify")]
 use notify::{can_notify, notify_err_async, notify_err_sync, will_notify_async};
 

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -7,7 +7,7 @@ use crate::{Err, ReasonContainer, SendSyncNonNull};
 #[cfg(feature = "notify")]
 mod notify;
 #[cfg(feature = "notify")]
-pub use notify::{add_async_err_handler, add_sync_err_handler, fix_err_handlers};
+pub use notify::{__add_async_err_handler, add_sync_err_handler, fix_err_handlers};
 #[cfg(feature = "notify")]
 use notify::{can_notify, notify_err_async, notify_err_sync, will_notify_async};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,19 +76,19 @@
 //! synchronously or asynchronously.
 //! To register error handlers that receive notifications synchronously, use the
 //! `add_sync_err_handler` function.
-//! For asynchronous notifications, use the `add_async_err_handler` function.
+//! For asynchronous notifications, use the `add_async_err_handler!` macro function.
 //!
 //! Error notifications will not occur until the `fix_err_handlers` function is called.
 //! This function locks the current set of error handlers, preventing further additions and
 //! enabling notification processing.
 //!
-//! ```
-//! errs::add_async_err_handler(|err, tm| {
+//! ```rust
+//! errs::add_async_err_handler!(async |err, tm| {
 //!     println!("{}:{}:{} - {}", tm, err.file, err.line, err);
 //! });
 //!
-//! errs::add_sync_err_handler(|info, tm| {
-//!     // ...
+//! errs::add_sync_err_handler(|err, tm| {
+//!     println!("{}:{}:{} - {}", tm, err.file, err.line, err);
 //! });
 //!
 //! errs::fix_err_handlers();
@@ -100,7 +100,7 @@ mod err;
 
 #[cfg(feature = "notify")]
 #[cfg_attr(docsrs, doc(cfg(feature = "notify")))]
-pub use err::{add_async_err_handler, add_sync_err_handler, fix_err_handlers};
+pub use err::{__add_async_err_handler, add_sync_err_handler, fix_err_handlers};
 
 use std::any;
 use std::error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ mod err;
 
 #[cfg(feature = "notify")]
 #[cfg_attr(docsrs, doc(cfg(feature = "notify")))]
-pub use err::{__add_async_err_handler, add_sync_err_handler, fix_err_handlers};
+pub use err::{add_raw_async_err_handler, add_sync_err_handler, fix_err_handlers};
 
 use std::any;
 use std::error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@
 //! synchronously or asynchronously.
 //! To register error handlers that receive notifications synchronously, use the
 //! `add_sync_err_handler` function.
-//! For asynchronous notifications, use the `add_async_err_handler!` macro function.
+//! For asynchronous notifications, use the `add_async_err_handler!` macro.
 //!
 //! Error notifications will not occur until the `fix_err_handlers` function is called.
 //! This function locks the current set of error handlers, preventing further additions and


### PR DESCRIPTION
This PR rewrites the implementation related to error notifications. The list used to store error handlers was a custom linked list implemented with pointers, but this has been changed to a `Vec`.

Additionally, the implementation for managing error handlers was changed to a safe combination of `Mutex<Vec>` and `OnceLock<Vec>`. This accounts for the fact that before `fix_err_handlers` is called, error handlers can be added from various locations in no particular order. After `fix_err_handlers` is executed, no more handlers can be added, and the list becomes read-only.

Furthermore, with these changes, asynchronous error handlers can now be registered as asynchronous functions (Future-creating functions). However, a new constraint emerged where handlers had to be wrapped in `Pin<Box<...>>`. To allow handlers to be written as a simple async block, `add_async_errs_handler` was converted into a macro.

Closes #19 Closes #18 