### PR TITLE
refactor: used NonNull for pointers in ReasonContainer to improve safety

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,9 +145,9 @@ where
     R: fmt::Debug + Send + Sync + 'static,
 {
     is_fn: fn(any::TypeId) -> bool,
-    drop_fn: fn(*const ReasonContainer),
-    debug_fn: fn(*const ReasonContainer, f: &mut fmt::Formatter<'_>) -> fmt::Result,
-    display_fn: fn(*const ReasonContainer, f: &mut fmt::Formatter<'_>) -> fmt::Result,
+    drop_fn: fn(ptr::NonNull<ReasonContainer>),
+    debug_fn: fn(ptr::NonNull<ReasonContainer>, f: &mut fmt::Formatter<'_>) -> fmt::Result,
+    display_fn: fn(ptr::NonNull<ReasonContainer>, f: &mut fmt::Formatter<'_>) -> fmt::Result,
     reason: R,
     is_referenced_by_another: Option<atomic::AtomicBool>,
 }


### PR DESCRIPTION
This PR makes the implementation safer by changing the internal struct `ReasonContainer` to use `NonNull` when passing its own pointer as an argument to a function that operates on itself.