### PR TITLE
fix: changed to use GracefulPhasedCellSync for Err handler store

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,15 @@ categories = ["rust-patterns"]
 
 [dependencies]
 chrono = { version = "0.4", optional = true }
-setup_read_cleanup = { "version" = "0.4", optional = true }
+setup_read_cleanup = { "version" = "0.5", optional = true }
 
 [dev-dependencies]
 trybuild = "1"
 
 [features]
-errs-notify = ["dep:setup_read_cleanup", "dep:chrono"]
+errs-notify = ["setup_read_cleanup/setup_read_cleanup-graceful", "dep:chrono"]
 default = []
+full = ["errs-notify"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,12 @@ compile() {
 }
 
 test() {
-  cargo test --all-features -- --show-output
+  echo "### features: default"
+  cargo test --features default -- --show-output
+  errcheck $?
+
+  echo "### features: errs-notify"
+  cargo test --features errs-notify -- --show-output
   errcheck $?
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,14 +84,17 @@
 //! enabling notification processing.
 //!
 //! ```rust
+//! #[cfg(feature = "errs-notify")]
 //! errs::add_async_err_handler(|err, tm| {
 //!     println!("{}:{}:{} - {}", tm, err.file(), err.line(), err);
 //! });
 //!
+//! #[cfg(feature = "errs-notify")]
 //! errs::add_sync_err_handler(|err, tm| {
 //!     println!("{}:{}:{} - {}", tm, err.file(), err.line(), err);
 //! });
 //!
+//! #[cfg(feature = "errs-notify")]
 //! errs::fix_err_handlers();
 //! ```
 


### PR DESCRIPTION
This PR replaces `PhasedCellSync` with `GracefulPhasedCellSync` to prevent error handling from failing when an `Err` instance is created without explicitly calling `fix_err_handlers` but it is in transitioning from Setup to Read in `PhasedCellSync`.

Closes #36