### PR TITLE
fix: removed setup_read_cleanup-on-tokio from features section in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["rust-patterns"]
 
 [dependencies]
 chrono = { version = "0.4", optional = true }
-tokio = { version = "1", optional = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"], optional = true }
 setup_read_cleanup = { "version" = "0.5", optional = true }
 
 [dev-dependencies]
@@ -22,7 +22,7 @@ trybuild = "1"
 
 [features]
 errs-notify = ["setup_read_cleanup/setup_read_cleanup-graceful", "dep:chrono"]
-errs-notify-tokio = ["setup_read_cleanup/setup_read_cleanup-graceful", "setup_read_cleanup/setup_read_cleanup-on-tokio", "dep:chrono", "dep:tokio"]
+errs-notify-tokio = ["setup_read_cleanup/setup_read_cleanup-graceful", "dep:chrono", "dep:tokio"]
 default = []
 full = ["errs-notify", "errs-notify-tokio"]
 

--- a/src/notify/tokio_handler.rs
+++ b/src/notify/tokio_handler.rs
@@ -282,14 +282,14 @@ mod tests_of_notify {
             assert!(fix_handlers(&HANDLERS).is_ok());
 
             assert!(add_tokio_async_handler(&HANDLERS, async |err, _tm| {
-                std::thread::sleep(tokio::time::Duration::from_millis(10));
+                std::thread::sleep(std::time::Duration::from_millis(10));
                 LOGGERS.lock().unwrap().push(format!("1: err={err:?}"));
             })
             .is_err());
             // When rust version is less than 1.85.
             //assert!(
             //    add_tokio_async_handler(&HANDLERS, |err: Arc<Err>, _tm| Box::pin(async move {
-            //        std::thread::sleep(tokio::time::Duration::from_millis(10));
+            //        std::thread::sleep(std::::Duration::from_millis(10));
             //        LOGGERS.lock().unwrap().push(format!("1: err={err:?}"));
             //    }))
             //    .is_err()


### PR DESCRIPTION
This PR removes the dependency `setup_read_cleanup/setup_read_cleanup-on-tokio` from the feature `errs-notify-tokio` because this crate does use neither `PhasedCellAsync` nor `GracefulPhasedCellAsync`.

