### PR TITLE
refactor: use Vec::splice for prepending handlers

### DIFF
--- a/src/notify/std_handler.rs
+++ b/src/notify/std_handler.rs
@@ -272,19 +272,17 @@ macro_rules! add_async_err_handler {
 fn register_handlers_by_inventory(
     vv: &mut (Vec<SyncBoxedFn>, Vec<AsyncArcFn>),
 ) -> Result<(), ErrHandlingError> {
-    let mut vec: Vec<SyncBoxedFn> = inventory::iter::<SyncHandlerRegistration>
+    let vec: Vec<SyncBoxedFn> = inventory::iter::<SyncHandlerRegistration>
         .into_iter()
         .map(|reg| Box::new(reg.handler) as SyncBoxedFn)
         .collect();
-    vec.append(&mut vv.0);
-    vv.0 = vec;
+    vv.0.splice(0..0, vec);
 
-    let mut vec: Vec<AsyncArcFn> = inventory::iter::<AsyncHandlerRegistration>
+    let vec: Vec<AsyncArcFn> = inventory::iter::<AsyncHandlerRegistration>
         .into_iter()
         .map(|reg| Arc::new(reg.handler) as AsyncArcFn)
         .collect();
-    vec.append(&mut vv.1);
-    vv.1 = vec;
+    vv.1.splice(0..0, vec);
 
     Ok(())
 }

--- a/src/notify/tokio_handler.rs
+++ b/src/notify/tokio_handler.rs
@@ -236,12 +236,11 @@ macro_rules! add_tokio_async_err_handler {
 }
 
 fn register_handlers_by_inventory(v: &mut Vec<TokioAsyncFn>) -> Result<(), ErrHandlingError> {
-    let mut vec: Vec<TokioAsyncFn> = inventory::iter::<TokioAsyncHandlerRegistration>
+    let vec: Vec<TokioAsyncFn> = inventory::iter::<TokioAsyncHandlerRegistration>
         .into_iter()
         .map(|reg| Box::new(reg.handler) as TokioAsyncFn)
         .collect();
-    vec.append(&mut *v);
-    *v = vec;
+    v.splice(0..0, vec);
 
     Ok(())
 }


### PR DESCRIPTION
This PR refactors the handler registration logic in `std_handler.rs` and `tokio_handler.rs`.

Previously, handlers collected from inventory were prepended to the existing list of handlers using a combination of `Vec::append` and reassignment. This approach was less direct and potentially inefficient, as it involved creating a new vector and moving all elements.

This change replaces the previous method with `Vec::splice(0..0, ...)`, which offers two main benefits:

1. Improved Efficiency: `Vec::splice` is the idiomatic and more performant way to insert elements from one collection into another at a specific position. It can often perform the insertion with fewer memory allocations and data movements.
2. Enhanced Readability: The use of `splice` makes the code's intent clearer. It directly expresses the action of "inserting elements at the beginning of the vector" in a single, concise operation.

These changes improve both the performance and maintainability of the error handling notification system.
