### PR TITLE
perf: slightly improved the performance of phase checking and transitioning in handle_err

### DIFF
--- a/src/notify/tokio_handler.rs
+++ b/src/notify/tokio_handler.rs
@@ -72,29 +72,32 @@ pub(crate) fn handle_err(
     err: Arc<Err>,
     tm: DateTime<Utc>,
 ) -> Result<(), ErrHandlingError> {
-    let result = match handlers.transition_to_read(register_handlers_by_inventory) {
-        Ok(_) => handlers.read(),
-        Err(e) => match e.kind() {
-            PhasedErrorKind::PhaseIsAlreadyRead => handlers.read_relaxed(),
-            PhasedErrorKind::DuringTransitionToRead => handlers.read(),
-            PhasedErrorKind::InternalDataUnavailable => {
-                return Err(ErrHandlingError::new(
-                    ErrHandlingErrorKind::InvalidInternalState,
-                ));
-            }
-            PhasedErrorKind::InternalDataMutexIsPoisoned => {
-                return Err(ErrHandlingError::new(
-                    ErrHandlingErrorKind::StdMutexIsPoisoned,
-                ));
-            }
-            // PhasedErrorKind::FailToRunClosureDuringTransitionToRead => {}, // impossible case
-            _ => {
-                return Err(ErrHandlingError::new(
-                    ErrHandlingErrorKind::InvalidCallTiming,
-                ));
-            }
-        },
-    };
+    let mut result = handlers.read_relaxed();
+    if result.is_err() {
+        result = match handlers.transition_to_read(register_handlers_by_inventory) {
+            Ok(_) => handlers.read_relaxed(),
+            Err(e) => match e.kind() {
+                PhasedErrorKind::PhaseIsAlreadyRead => handlers.read_relaxed(),
+                PhasedErrorKind::DuringTransitionToRead => handlers.read(),
+                PhasedErrorKind::InternalDataUnavailable => {
+                    return Err(ErrHandlingError::new(
+                        ErrHandlingErrorKind::InvalidInternalState,
+                    ));
+                }
+                PhasedErrorKind::InternalDataMutexIsPoisoned => {
+                    return Err(ErrHandlingError::new(
+                        ErrHandlingErrorKind::StdMutexIsPoisoned,
+                    ));
+                }
+                // PhasedErrorKind::FailToRunClosureDuringTransitionToRead => {}, // impossible case
+                _ => {
+                    return Err(ErrHandlingError::new(
+                        ErrHandlingErrorKind::InvalidCallTiming,
+                    ));
+                }
+            },
+        };
+    }
 
     match result {
         Ok(v) => {


### PR DESCRIPTION
Currently, even when `PhasedCell` is already in the `Read` phase, we always perform a phase check using `transition_to_read` (with `Ordering::Acquire`), followed by another redundant phase check via `read_relaxed` before accessing the internal data.

Since `transition_to_read` is only necessary during the very brief period when the phase is `Setup` or `Setup-to-Read`, this constant use of expensive atomic operations is inefficient. Therefore, I have modified the logic to execute `read_relaxed` first. `transition_to_read` will now only be called as a fallback if the initial relaxed check fails.