### PR TITLE
cicd: updated the Rust version for CI to 〜1.95.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rustver: ['1.85.0', '1.89.0', '1.94.0']
+        rustver: ['1.85.0', '1.89.0', '1.95.0']
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
T/O.