### PR TITLE
new: implement safe Clone for errs::Err using reference counting

### DIFF
--- a/src/err.rs
+++ b/src/err.rs
@@ -7,10 +7,8 @@ use crate::{Err, ReasonAndSource, SendSyncNonNull};
 #[cfg(any(feature = "notify", feature = "notify-tokio"))]
 use crate::notify;
 
-use std::{any, error, fmt, marker, panic, ptr};
-
-#[cfg(any(feature = "notify", feature = "notify-tokio"))]
 use std::sync::atomic;
+use std::{any, error, fmt, marker, panic, process, ptr};
 
 unsafe impl<T: Send + Sync> Send for SendSyncNonNull<T> {}
 unsafe impl<T: Send + Sync> Sync for SendSyncNonNull<T> {}
@@ -56,31 +54,20 @@ impl Err {
         let boxed = Box::new(ReasonAndSource::<R>::new(reason));
         let ptr = ptr::NonNull::from(Box::leak(boxed)).cast::<ReasonAndSource>();
 
+        let err = Self {
+            file: loc.file(),
+            line: loc.line(),
+            reason_and_source: SendSyncNonNull::new(ptr),
+        };
+
         #[cfg(any(feature = "notify", feature = "notify-tokio"))]
         {
-            let err_notified = Self {
-                file: loc.file(),
-                line: loc.line(),
-                reason_and_source: SendSyncNonNull::new(ptr),
-            };
-            if let Err(e) = notify::notify_err(err_notified) {
-                eprintln!("ERROR(errs): {e:?}");
+            if let Err(e) = notify::notify_err(err.clone()) {
+                eprintln!("ERROR(errs): failed to notify error={err:?}: {e:?}");
             }
+        }
 
-            Self {
-                file: loc.file(),
-                line: loc.line(),
-                reason_and_source: SendSyncNonNull::new(ptr),
-            }
-        }
-        #[cfg(not(any(feature = "notify", feature = "notify-tokio")))]
-        {
-            Self {
-                file: loc.file(),
-                line: loc.line(),
-                reason_and_source: SendSyncNonNull::new(ptr),
-            }
-        }
+        err
     }
 
     /// Creates a new `Err` instance with the give reason and underlying source error.
@@ -119,31 +106,20 @@ impl Err {
         let boxed = Box::new(ReasonAndSource::<R, E>::with_source(reason, source));
         let ptr = ptr::NonNull::from(Box::leak(boxed)).cast::<ReasonAndSource>();
 
+        let err = Self {
+            file: loc.file(),
+            line: loc.line(),
+            reason_and_source: SendSyncNonNull::new(ptr),
+        };
+
         #[cfg(any(feature = "notify", feature = "notify-tokio"))]
         {
-            let err_notified = Self {
-                file: loc.file(),
-                line: loc.line(),
-                reason_and_source: SendSyncNonNull::new(ptr),
-            };
-            if let Err(e) = notify::notify_err(err_notified) {
-                eprintln!("ERROR(errs): {e:?}");
+            if let Err(e) = notify::notify_err(err.clone()) {
+                eprintln!("ERROR(errs): failed to notify error={err:?}: {e:?}");
             }
+        }
 
-            Self {
-                file: loc.file(),
-                line: loc.line(),
-                reason_and_source: SendSyncNonNull::new(ptr),
-            }
-        }
-        #[cfg(not(any(feature = "notify", feature = "notify-tokio")))]
-        {
-            Self {
-                file: loc.file(),
-                line: loc.line(),
-                reason_and_source: SendSyncNonNull::new(ptr),
-            }
-        }
+        err
     }
 
     /// Gets the name of the source file where the error occurred.
@@ -261,6 +237,25 @@ impl Err {
     }
 }
 
+const MAX_REF_COUNT: usize = (isize::MAX) as usize;
+
+impl Clone for Err {
+    fn clone(&self) -> Self {
+        let ptr = self.reason_and_source.non_null_ptr.as_ptr();
+        let old_count = unsafe { &(*ptr).ref_count }.fetch_add(1, atomic::Ordering::Relaxed);
+
+        if old_count > MAX_REF_COUNT {
+            process::abort();
+        }
+
+        Self {
+            file: self.file,
+            line: self.line,
+            reason_and_source: SendSyncNonNull::new(self.reason_and_source.non_null_ptr),
+        }
+    }
+}
+
 impl Drop for Err {
     fn drop(&mut self) {
         let drop_fn = unsafe { (*self.reason_and_source.non_null_ptr.as_ptr()).drop_fn };
@@ -305,8 +300,7 @@ where
             debug_fn: debug_reason_and_source::<R, E>,
             display_fn: display_reason_and_source::<R, E>,
             source_fn: get_source::<R, E>,
-            #[cfg(any(feature = "notify", feature = "notify-tokio"))]
-            is_referenced_by_another: atomic::AtomicBool::new(true),
+            ref_count: atomic::AtomicUsize::new(1),
             reason_and_source: (reason, None),
         }
     }
@@ -318,8 +312,7 @@ where
             debug_fn: debug_reason_and_source::<R, E>,
             display_fn: display_reason_and_source::<R, E>,
             source_fn: get_source::<R, E>,
-            #[cfg(any(feature = "notify", feature = "notify-tokio"))]
-            is_referenced_by_another: atomic::AtomicBool::new(true),
+            ref_count: atomic::AtomicUsize::new(1),
             reason_and_source: (reason, Some(*Box::new(source))),
         }
     }
@@ -338,16 +331,21 @@ where
     E: error::Error + Send + Sync + 'static,
 {
     let typed_ptr = ptr.cast::<ReasonAndSource<R, E>>().as_ptr();
-    #[cfg(any(feature = "notify", feature = "notify-tokio"))]
-    {
-        let is_ref = unsafe { &(*typed_ptr).is_referenced_by_another };
-        if !is_ref.fetch_and(false, atomic::Ordering::AcqRel) {
-            unsafe { drop(Box::from_raw(typed_ptr)) };
-        }
-    }
-    #[cfg(not(any(feature = "notify", feature = "notify-tokio")))]
-    {
+    let old_count = unsafe {
+        (*typed_ptr)
+            .ref_count
+            .fetch_sub(1, atomic::Ordering::AcqRel)
+    };
+    if old_count == 1 {
+        // Ensure that any memory accesses from other threads are synchronized
+        // before we proceed with dropping the data. This synchronizes with
+        // the Release operation in fetch_sub.
+        atomic::fence(atomic::Ordering::Acquire);
+
         unsafe { drop(Box::from_raw(typed_ptr)) };
+    } else if old_count == 0 {
+        // impossible case
+        process::abort();
     }
 }
 
@@ -857,6 +855,35 @@ mod tests_of_err {
                 }
                 _ => panic!(),
             });
+        }
+    }
+
+    mod test_of_clone_and_drop {
+        use super::*;
+
+        #[test]
+        fn test_sync() {
+            let err0 = Err::new("1");
+            let err1 = err0.clone();
+            {
+                let _err2 = err0.clone();
+            }
+            let _err3 = err1.clone();
+        }
+
+        #[test]
+        fn test_async() {
+            let err0 = Err::new("1");
+
+            for _i in 1..10 {
+                let err = err0.clone();
+                std::thread::spawn(move || {
+                    let _s = err.reason::<&str>();
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                });
+            }
+
+            std::thread::sleep(std::time::Duration::from_millis(100));
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,11 +227,8 @@ pub use notify::{add_tokio_async_err_handler, TokioAsyncHandlerRegistration};
 #[cfg_attr(docsrs, doc(cfg(any(feature = "notify", feature = "notify-tokio"))))]
 pub use notify::{fix_err_handlers, ErrHandlingError, ErrHandlingErrorKind};
 
-use std::{any, cell, error, fmt, marker, ptr, result};
-
-#[cfg(any(feature = "notify", feature = "notify-tokio"))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "notify", feature = "notify-tokio"))))]
 use std::sync::atomic;
+use std::{any, cell, error, fmt, marker, ptr, result};
 
 /// Struct that represents an error with a reason.
 ///
@@ -278,8 +275,7 @@ where
     debug_fn: fn(ptr::NonNull<ReasonAndSource>, f: &mut fmt::Formatter<'_>) -> fmt::Result,
     display_fn: fn(ptr::NonNull<ReasonAndSource>, f: &mut fmt::Formatter<'_>) -> fmt::Result,
     source_fn: fn(ptr::NonNull<ReasonAndSource>) -> Option<&'static (dyn error::Error + 'static)>,
-    #[cfg(any(feature = "notify", feature = "notify-tokio"))]
-    is_referenced_by_another: atomic::AtomicBool,
+    ref_count: atomic::AtomicUsize,
     reason_and_source: (R, Option<E>),
 }
 

--- a/tests/compile_errors/lifetime_of_reason_in_dropped_errs.stderr
+++ b/tests/compile_errors/lifetime_of_reason_in_dropped_errs.stderr
@@ -10,3 +10,8 @@ error[E0505]: cannot move out of `err` because it is borrowed
    |               ^^^ move out of `err` occurs here
 20 |   println!("{:?}", reason);
    |                    ------ borrow later used here
+   |
+help: consider cloning the value if the performance cost is acceptable
+   |
+17 |   let reason = err.clone().reason::<Reasons>().unwrap();
+   |                   ++++++++


### PR DESCRIPTION
Closes #67 

This PR implements the `Clone` trait for the `errs::Err` struct in a memory-safe manner using reference counting. This allows error instances to be safely shared across multiple threads or asynchronous handlers.

### Motivation
Previously, `errs::Err` did not implement `Clone`. If a user attempted to bypass this by adding `#[derive(Clone)]`, it would result in shallow copies of the internal pointer, leading to double-free issues or undefined behavior (UB) during drop. Additionally, the internal error notification logic (notify) had to manually reconstruct instances, leading to redundant and complex code.

### Changes
- **Reference Counting:** Added ref_count: `AtomicUsize` to the `ReasonAndSource` struct.
- **Clone Implementation:** Implemented `Clone` to increment the reference counter.
- **Drop Implementation:** Updated `Drop` to decrement the counter and only free the underlying memory when the count reaches zero.
- **Thread Safety:** Used standard atomic patterns (e.g., `AcqRel` ordering and `Acquire` fences) to ensure safe memory synchronization across threads, similar to `std::sync::Arc`.
- **Refactoring:** Simplified internal logic in `Err::new` and `Err::with_source` by utilizing the new `clone()` method for notification handling.

### Verification
- **New Unit Tests:**
       - Synchronous tests for multiple clone and drop cycles within a single thread.
       - Asynchronous tests to verify memory safety when instances are cloned and dropped across multiple spawned threads.
- **Regression Testing:** Confirmed that all existing integration tests and documentation tests pass via `cargo test`.
