### PR TITLE
update!: changed Err::match_reason method to matcher-based chaning API

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ The `Err` struct can be instantiated with `new<R>(reason: R)` function or
 `with_source<R, E>(reason: R, source: E)` function.
 
 Then, the reason can be identified with `reason<R>(&self)` method and a `match` statement,
-or `match_reason<R>(&self, func fn(&R))` method.
+or `match_reason<R, T>(&self, func: impl FnOnce(&R) -> Result<T, Err>)` method.
 
 The following code is an example which uses `new<R>(reason: R)` function for instantiation,
 and `reason<R>(&self)` method and a `match` statement for identifying a reason:
 
-```
+```rust
 use errs::Err;
 
 #[derive(Debug)]
@@ -64,6 +64,31 @@ match err.reason::<Reasons>() {
         Err(err) => { /* ... */ }
     }
 }
+```
+
+The following code is an example which uses `match_reason`, `or_match_reason`, and `or_result`
+methods for identifying a reason in a chaining manner:
+
+```rust
+use errs::Err;
+
+#[derive(Debug)]
+enum Reasons {
+    IllegalState { state: String },
+    // ...
+}
+
+let err = Err::new(Reasons::IllegalState { state: "bad state".to_string() });
+
+let state = err.match_reason::<Reasons, String>(|r| match r {
+    Reasons::IllegalState { state } => Ok(state.clone()),
+}).or_match_reason::<String>(|s| {
+    Ok(s.clone())
+}).or_result(|_err| {
+    Ok("unknown".to_string())
+}).unwrap();
+
+assert_eq!(state, "bad state");
 ```
 
 ### Function-based Error Handler Registration

--- a/src/err.rs
+++ b/src/err.rs
@@ -2,7 +2,7 @@
 // This program is free software under MIT License.
 // See the file LICENSE in this distribution for more details.
 
-use crate::{Err, ReasonAndSource, SendSyncNonNull};
+use crate::{Err, ReasonAndSource, ReasonMatcher, SendSyncNonNull};
 
 #[cfg(any(feature = "notify", feature = "notify-tokio"))]
 use crate::notify;
@@ -190,50 +190,89 @@ impl Err {
         }
     }
 
-    /// Executes a function if the error's reason matches a specific type.
+    /// Matches the reason of this error with a specified type.
     ///
-    /// This method allows you to perform actions based on the type of the error's reason.
-    /// If the reason matches the expected type, the provided function is called with
-    /// a reference to the reason.
+    /// If the reason matches the type `R`, the provided function `func` is called with a reference
+    /// to the reason.
+    /// This method returns a [`ReasonMatcher`] that allows for further chaining with
+    /// [`or_match_reason`](ReasonMatcher::or_match_reason) or finalizing with
+    /// [`or_result`](ReasonMatcher::or_result).
     ///
-    /// # Parameters
-    /// - `R`: The expected type of the reason.
-    /// - `func`: The function to execute if the reason matches the type.
-    ///
-    /// # Returns
-    /// A reference to the current `Err` instance.
-    ///
+    /// # Examples
     ///
     /// ```rust
     /// use errs::Err;
     ///
     /// #[derive(Debug)]
-    /// enum Reasons {
-    ///     IllegalState { state: String },
-    /// }
+    /// enum IoErrs { FileNotFound { path: String } }
     ///
-    /// let err = Err::new(Reasons::IllegalState { state: "bad state".to_string() });
-    /// err.match_reason::<Reasons>(|r| match r {
-    ///     Reasons::IllegalState { state } => println!("state = {state}"),
-    ///     _ => { /* ... */ }
-    /// })
-    /// .match_reason::<String>(|s| {
-    ///     println!("string reason = {s}");
-    /// });
+    /// let err = Err::new(IoErrs::FileNotFound { path: "test.txt".to_string() });
+    ///
+    /// let result = err.match_reason::<IoErrs, String>(|r| match r {
+    ///     IoErrs::FileNotFound { path } => Ok(path.clone()),
+    /// }).or_match_reason::<String>(|s| {
+    ///     Ok(s.clone())
+    /// }).or_result(|_| Ok("default".to_string()));
+    ///
+    /// assert_eq!(result.unwrap(), "test.txt");
     /// ```
-    pub fn match_reason<R>(&self, func: fn(&R)) -> &Self
+    pub fn match_reason<R, T>(&self, func: impl FnOnce(&R) -> Result<T, Err>) -> ReasonMatcher<T>
     where
         R: fmt::Debug + Send + Sync + 'static,
     {
         let type_id = any::TypeId::of::<R>();
         let ptr = self.reason_and_source.non_null_ptr.as_ptr();
         let is_fn = unsafe { (*ptr).is_fn };
-        if is_fn(type_id) {
+        let result = if is_fn(type_id) {
             let typed_ptr = ptr as *const ReasonAndSource<R>;
-            func(unsafe { &((*typed_ptr).reason_and_source.0) });
-        }
+            Ok(func(unsafe { &((*typed_ptr).reason_and_source.0) }))
+        } else {
+            Err(self.clone())
+        };
+        ReasonMatcher { result }
+    }
+}
 
-        self
+impl<T> ReasonMatcher<T> {
+    /// Matches the reason of the error with another specified type if previous matches failed.
+    ///
+    /// If the previous match attempts in the chain did not find a matching type, and the reason
+    /// matches the type `R`, the provided function `func` is called with a reference to the
+    /// reason.
+    pub fn or_match_reason<R>(self, func: impl FnOnce(&R) -> Result<T, Err>) -> ReasonMatcher<T>
+    where
+        R: fmt::Debug + Send + Sync + 'static,
+    {
+        match self.result {
+            Ok(result) => ReasonMatcher { result: Ok(result) },
+            Err(err) => {
+                let type_id = any::TypeId::of::<R>();
+                let ptr = err.reason_and_source.non_null_ptr.as_ptr();
+                let is_fn = unsafe { (*ptr).is_fn };
+                if is_fn(type_id) {
+                    let typed_ptr = ptr as *const ReasonAndSource<R>;
+                    ReasonMatcher {
+                        result: Ok(func(unsafe { &((*typed_ptr).reason_and_source.0) })),
+                    }
+                } else {
+                    ReasonMatcher { result: Err(err) }
+                }
+            }
+        }
+    }
+
+    /// Finalizes the matching chain and returns the result.
+    ///
+    /// If any of the matches in the chain succeeded, its result is returned.
+    /// Otherwise, the provided function `f` is called with the original error.
+    pub fn or_result<F>(self, f: F) -> Result<T, Err>
+    where
+        F: FnOnce(&Err) -> Result<T, Err>,
+    {
+        match self.result {
+            Ok(result) => result,
+            Err(err) => f(&err),
+        }
     }
 }
 
@@ -824,6 +863,12 @@ mod tests_of_err {
             FailToGetValue { name: String },
         }
 
+        #[allow(dead_code)]
+        #[derive(Debug)]
+        enum Enum1 {
+            BadValue,
+        }
+
         #[test]
         fn reason_is_enum() {
             let err = Err::new(Enum0::InvalidValue {
@@ -845,16 +890,40 @@ mod tests_of_err {
                 },
             }
 
-            err.match_reason::<String>(|_s| {
-                panic!();
-            })
-            .match_reason::<Enum0>(|r| match r {
-                Enum0::InvalidValue { name, value } => {
-                    assert_eq!(name, "foo");
-                    assert_eq!(value, "abc");
-                }
-                _ => panic!(),
-            });
+            let result: Result<u8, Err> = err
+                .match_reason::<Enum0, u8>(|r| match r {
+                    Enum0::InvalidValue { name, value } => {
+                        assert_eq!(name, "foo");
+                        assert_eq!(value, "abc");
+                        Ok(123u8)
+                    }
+                    _ => panic!(),
+                })
+                .or_result(|_e| Err(Err::new("fail")));
+
+            assert_eq!(result.unwrap(), 123);
+
+            let result: Result<u8, Err> = err
+                .match_reason::<String, u8>(|_s| Ok(0u8))
+                .or_match_reason::<Enum0>(|r| match r {
+                    Enum0::InvalidValue { name, value } => {
+                        assert_eq!(name, "foo");
+                        assert_eq!(value, "abc");
+                        Ok(123u8)
+                    }
+                    _ => panic!(),
+                })
+                .or_match_reason::<Enum1>(|_r| Ok(1u8))
+                .or_result(|_e| Err(Err::new("fail")));
+
+            assert_eq!(result.unwrap(), 123);
+
+            let result: Result<u8, Err> = err
+                .match_reason::<String, u8>(|_s| Ok(0u8))
+                .or_match_reason::<Enum1>(|_r| Ok(1u8))
+                .or_result(|_e| Err(Err::new("fail")));
+
+            assert_eq!(result.unwrap_err().reason::<&str>().unwrap(), &"fail");
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,12 +53,12 @@
 //! `with_source<R, E>(reason: R, source: E)` function.
 //!
 //! Then, the reason can be identified with `reason<R>(&self)` method and a `match` statement,
-//! or `match_reason<R>(&self, func fn(&R))` method.
+//! or `match_reason<R, T>(&self, func: impl FnOnce(&R) -> Result<T, Err>)` method.
 //!
 //! The following code is an example which uses `new<R>(reason: R)` function for instantiation,
 //! and `reason<R>(&self)` method and a `match` statement for identifying a reason:
 //!
-//! ```
+//! ```rust
 //! use errs::Err;
 //!
 //! #[derive(Debug)]
@@ -79,6 +79,30 @@
 //!         Err(err) => { /* ... */ }
 //!     }
 //! }
+//! ```
+//!
+//! The following code is an example which uses `match_reason` method for identifying a reason:
+//!
+//! ```rust
+//! use errs::Err;
+//!
+//! #[derive(Debug)]
+//! enum Reasons {
+//!     IllegalState { state: String },
+//!     // ...
+//! }
+//!
+//! let err = Err::new(Reasons::IllegalState { state: "bad state".to_string() });
+//!
+//! let state = err.match_reason::<Reasons, String>(|r| match r {
+//!     Reasons::IllegalState { state } => Ok(state.clone()),
+//! }).or_match_reason::<String>(|s| {
+//!     Ok(s.clone())
+//! }).or_result(|_err| {
+//!     Ok("unknown".to_string())
+//! }).unwrap();
+//!
+//! assert_eq!(state, "bad state");
 //! ```
 //!
 //! ### Macro-based Registration of Err Handlers
@@ -342,3 +366,10 @@ struct SendSyncNonNull<T: Send + Sync> {
 /// }
 /// ```
 pub type Result<T> = result::Result<T, Err>;
+
+/// A matcher for the reason of an error.
+///
+/// This struct is created by [`Err::match_reason`].
+pub struct ReasonMatcher<T> {
+    result: std::result::Result<std::result::Result<T, Err>, Err>,
+}

--- a/tests/errs_test.rs
+++ b/tests/errs_test.rs
@@ -87,36 +87,63 @@ mod integration_tests_of_err {
     fn should_match_reason() {
         match find_file() {
             Ok(_) => panic!(),
-            Err(err) => err.match_reason::<IoErrs>(|r| match r {
-                IoErrs::FileNotFound { path } => {
-                    assert_eq!(path, "/aaa/bbb/ccc");
-                }
-                IoErrs::NoPermission { path: _, r#mod: _ } => panic!(),
-                IoErrs::DueToSomeError { path: _ } => panic!(),
-            }),
+            Err(err) => {
+                let Ok(s) = err
+                    .match_reason::<IoErrs, String>(|r| match r {
+                        IoErrs::FileNotFound { path } => {
+                            assert_eq!(path, "/aaa/bbb/ccc");
+                            Ok(path.to_string())
+                        }
+                        IoErrs::NoPermission { path: _, r#mod: _ } => panic!(),
+                        IoErrs::DueToSomeError { path: _ } => panic!(),
+                    })
+                    .or_result(|_err| Err(errs::Err::new("bad")))
+                else {
+                    panic!();
+                };
+                assert_eq!(s, "/aaa/bbb/ccc");
+            }
         };
 
         match read_file() {
             Ok(_) => panic!(),
-            Err(err) => err.match_reason::<IoErrs>(|r| match r {
-                IoErrs::FileNotFound { path: _ } => panic!(),
-                IoErrs::NoPermission { path, r#mod } => {
-                    assert_eq!(path, "/aaa/bbb/ccc");
-                    assert_eq!(*r#mod, (4, 4, 4));
-                }
-                IoErrs::DueToSomeError { path: _ } => panic!(),
-            }),
+            Err(err) => {
+                let Ok(s) = err
+                    .match_reason::<IoErrs, String>(|r| match r {
+                        IoErrs::FileNotFound { path: _ } => panic!(),
+                        IoErrs::NoPermission { path, r#mod } => {
+                            assert_eq!(path, "/aaa/bbb/ccc");
+                            assert_eq!(*r#mod, (4, 4, 4));
+                            Ok(path.to_string())
+                        }
+                        IoErrs::DueToSomeError { path: _ } => panic!(),
+                    })
+                    .or_result(|_err| Err(errs::Err::new("bad")))
+                else {
+                    panic!();
+                };
+                assert_eq!(s, "/aaa/bbb/ccc");
+            }
         };
 
         match write_file() {
             Ok(_) => panic!(),
-            Err(err) => err.match_reason::<IoErrs>(|r| match r {
-                IoErrs::FileNotFound { path: _ } => panic!(),
-                IoErrs::NoPermission { path: _, r#mod: _ } => panic!(),
-                IoErrs::DueToSomeError { path } => {
-                    assert_eq!(path, "/aaa/bbb/ccc");
-                }
-            }),
+            Err(err) => {
+                let Ok(s) = err
+                    .match_reason::<IoErrs, String>(|r| match r {
+                        IoErrs::FileNotFound { path: _ } => panic!(),
+                        IoErrs::NoPermission { path: _, r#mod: _ } => panic!(),
+                        IoErrs::DueToSomeError { path } => {
+                            assert_eq!(path, "/aaa/bbb/ccc");
+                            Ok(path.to_string())
+                        }
+                    })
+                    .or_result(|_err| Err(errs::Err::new("bad")))
+                else {
+                    panic!();
+                };
+                assert_eq!(s, "/aaa/bbb/ccc");
+            }
         };
     }
 


### PR DESCRIPTION
Closes #65

This PR changes the `Err#match_reason` method to return `ReasonMatcher` which has two chaining methods `on_match_reason` and `on_result`.