### PR TITLE
cicd: updated the latest Rust version used by CI to 1.97.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rustver: ['1.85.0', '1.89.0', '1.96.0']
+        rustver: ['1.85.0', '1.89.0', '1.97.1']
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Because Rust 1.97.1 was released on July 16, 2026.
https://blog.rust-lang.org/2026/07/16/Rust-1.97.1/